### PR TITLE
download files with index 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Test this as
 - link from github pages: [https://niccokunzmann.github.io/download_latest/](https://niccokunzmann.github.io/download_latest/)
 - release: [https://github.com/niccokunzmann/download_latest/releases/latest](https://github.com/niccokunzmann/download_latest/releases/latest)
 
-How To Use
+How to download a file of the latest release
 ----------
 
-### Default usecase By Owner
+### Download file by name
 
 In your markdown files in the repository or in your github pages, add a link:
 
@@ -29,32 +29,25 @@ In your markdown files in the repository or in your github pages, add a link:
 Replace `<FILE>` with the name of the file to download from the releases.
 If you want to specify repository and user, you can do so.
 
-### Awesome Feature
+### Download file by index
 
-If you are looking for a static way to download a file with index, without taking consideration of the file name, i have added an option to download files by index.
+If you are looking for a static way to download a file with index,
+without taking consideration of the file name,
+this is the option you are looking for
 
-I have implemented it this way: `?index=0..n`
+Ad the query parameter to the url like this: `?index=0..n`
 
- - When index is set, it download the file with that index from the latest release files.
- - If not set, it automatically bind the first file.
- - If a file name was set, it will behave normally as repository owner made it.
+ - The first file has index 0.
+ - When index is set, it downloads the file with that index from the latest release files. Example: `?index=5`
+ - If index is not set, the first file is downloaded. `?index=`
+ - If the index parameter is set, the file name is ignored.
 
-#### See it in action:
-
-    https://chlegou.github.io/download_latest/chlegou/bitbot/ // will automatically bind the first file in the latest release
     https://chlegou.github.io/download_latest/chlegou/bitbot/?index=0 // will download the 1st file in the latest release 
     https://chlegou.github.io/download_latest/chlegou/bitbot/?index=5 // will download the 6th file in the latest release 
     
-**IMPORTANT:** In case of multi files, you must take consideration of file's orders in releases (they must follow the same order always to have it working right).
-
-follow 
-[this](https://github.com/niccokunzmann/download_latest/issues/3)
-issue for more details.
-
-see changes from 
-[here](https://github.com/chlegou/download_latest/blob/8720051371b81c94ec629bc64e37342c7440b8ef/_includes/github.js#L35-L44)
-for code details.
-
+**IMPORTANT:** In case of multiple files, you must take consideration of the files' order in the releases.
+They must follow the same order always.
+Adding files may break the order.
 
 Contribute
 ----------
@@ -66,3 +59,8 @@ Related Work
 ------------
 
 This was creates as an answer to [this Stackoveflow question](http://stackoverflow.com/questions/24987542/is-there-a-link-to-github-for-downloading-a-file-in-the-latest-release-of-a-repo).
+
+Credits
+-------
+
+Work be [niccokunzmann](https://github.com/niccokunzmann) and [chlegou](https://github.com/chlegou).

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ Ad the query parameter to the url like this: `?index=0..n`
  - If index is not set, the first file is downloaded. `?index=`
  - If the index parameter is set, the file name is ignored.
 
-    https://chlegou.github.io/download_latest/chlegou/bitbot/?index=0 // will download the 1st file in the latest release 
-    https://chlegou.github.io/download_latest/chlegou/bitbot/?index=5 // will download the 6th file in the latest release 
-    
+```
+https://chlegou.github.io/download_latest/chlegou/bitbot/?index=0 // will download the 1st file in the latest release 
+https://chlegou.github.io/download_latest/chlegou/bitbot/?index=5 // will download the 6th file in the latest release 
+```
+
 **IMPORTANT:** In case of multiple files, you must take consideration of the files' order in the releases.
 They must follow the same order always.
 Adding files may break the order.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ I have implemented it this way: `?index=0..n`
 #### See it in action:
 
     https://chlegou.github.io/download_latest/chlegou/bitbot/ // will automatically bind the first file in the latest release
-    https://chlegou.github.io/download_latest/chlegou/bitbot/?index=5 // will download the 5th file in the latest release 
+    https://chlegou.github.io/download_latest/chlegou/bitbot/?index=0 // will download the 1st file in the latest release 
+    https://chlegou.github.io/download_latest/chlegou/bitbot/?index=5 // will download the 6th file in the latest release 
     
 **IMPORTANT:** In case of multi files, you must take consideration of file's orders in releases (they must follow the same order always to have it working right).
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+Credits
+===============
+
+This project was was originally developed by **@niccokunzmann**.
+
+[https://github.com/niccokunzmann/download_latest](https://github.com/niccokunzmann/download_latest)
+
 download_latest
 ===============
 
@@ -12,6 +19,8 @@ Test this as
 How To Use
 ----------
 
+### Default usecase By Owner
+
 In your markdown files in the repository or in your github pages, add a link:
 
     https://niccokunzmann.github.io/download_latest/<FILE>
@@ -19,6 +28,32 @@ In your markdown files in the repository or in your github pages, add a link:
 
 Replace `<FILE>` with the name of the file to download from the releases.
 If you want to specify repository and user, you can do so.
+
+### Awesome Feature
+
+If you are looking for a static way to download a file with index, without taking consideration of the file name, i have added an option to download files by index.
+
+I have implemented it this way: `?index=0..n`
+
+ - When index is set, it download the file with that index from the latest release files.
+ - If not set, it automatically bind the first file.
+ - If a file name was set, it will behave normally as repository owner made it.
+
+#### See it in action:
+
+    https://chlegou.github.io/download_latest/chlegou/bitbot/ // will automatically bind the first file in the latest release
+    https://chlegou.github.io/download_latest/chlegou/bitbot/?index=5 // will download the 5th file in the latest release 
+    
+**IMPORTANT:** In case of multi files, you must take consideration of file's orders in releases (they must follow the same order always to have it working right).
+
+follow 
+[this](https://github.com/niccokunzmann/download_latest/issues/3)
+issue for more details.
+
+see changes from 
+[here](https://github.com/chlegou/download_latest/blob/8720051371b81c94ec629bc64e37342c7440b8ef/_includes/github.js#L35-L44)
+for code details.
+
 
 Contribute
 ----------

--- a/_includes/common.js
+++ b/_includes/common.js
@@ -4,7 +4,7 @@
 function downloadAsset(asset) {
   document.location = asset;
   setStatus("Download started.");
-  setTimeout(window.close, 1000);
+  // setTimeout(window.close, 1000);
 }
   
 function couldNotDownloadAsset(text) {

--- a/_includes/common.js
+++ b/_includes/common.js
@@ -39,13 +39,6 @@ function parseRepository(referrer) {
   return null;
 }
 
-function downloadFrom(website) {
-  if (website) {
-  } else {
-    GithubRepository()
-  }
-}
-
 function startDownload() {
   var path = document.location.pathname.split("/").slice(1);
   /* We have these cases:
@@ -58,7 +51,7 @@ function startDownload() {
   if (path.length >= 3) {
     repository = new GithubRepository(path[path.length - 3], path[path.length - 2])
   } else if (document.referrer) {
-    repository = parseRepository(website);
+    repository = parseRepository(document.referrer);
   } else {
     couldNotDownloadAsset();
     return;

--- a/_includes/common.js
+++ b/_includes/common.js
@@ -3,7 +3,8 @@
 
 function downloadAsset(asset) {
   document.location = asset;
-  setStatus("Download started.")
+  setStatus("Download started.");
+  setTimeout(window.close, 1000);
 }
   
 function couldNotDownloadAsset(text) {

--- a/_includes/github.js
+++ b/_includes/github.js
@@ -6,28 +6,45 @@ function GithubRepository(user, repository) {
 }
 
 
-GithubRepository.prototype.getAssetName = function() {
+GithubRepository.prototype.getAssetName = function () {
   var split_path = document.location.pathname.split("/");
   return split_path[split_path.length - 1];
 }
 
-GithubRepository.prototype.redirectToReleaseFile = function(release) {
+GithubRepository.prototype.redirectToReleaseFile = function (release) {
   console.log(release);
   var assetName = this.getAssetName();
-  console.log("Looking for asset: " + assetName)
+
   var downloaded = false;
   var names = [];
-  for (var i = 0; i < release.assets.length; i+=1) {
-    var asset = release.assets[i];
-    names.push(asset.name);
-    if (asset.name == assetName) {
-      downloadAsset(asset.browser_download_url);
+  if(assetName.length > 0){
+    console.log("Looking for asset: " + assetName)
+    
+    for (var i = 0; i < release.assets.length; i += 1) {
+      var asset = release.assets[i];
+      names.push(asset.name);
+      if (asset.name == assetName) {
+        downloadAsset(asset.browser_download_url);
+        downloaded = true;
+      }
+    }
+    if (!downloaded) {
+      couldNotDownloadAsset("File " + assetName + " not found. Should be one of " + names.join(", ") + ".");
+    }
+  }else{
+    var index = this.getQueryParam("index");
+    // making 0 as default index
+    index = index ? index : 0;
+    if(release.assets.length > index){
+      downloadAsset(release.assets[index].browser_download_url);
       downloaded = true;
     }
+    if (!downloaded) {
+      couldNotDownloadAsset("No File Found with index " + assetName + ".");
+    }
+
   }
-  if (!downloaded) {
-    couldNotDownloadAsset("File " + assetName + " not found. Should be one of " + names.join(", ") + ".");
-  }
+  
 }
 
 GithubRepository.prototype.startDownload = function () {
@@ -41,3 +58,13 @@ GithubRepository.prototype.startDownload = function () {
 }
 
 
+/**
+ * get href query param by key
+ */
+GithubRepository.prototype.getQueryParam = function(param) {
+  var result = window.location.search.match(
+    new RegExp("(\\?|&)" + param + "(\\[\\])?=([^&]*)")
+  );
+
+  return result ? result[3] : false;
+}


### PR DESCRIPTION

### Awesome Feature

If you are looking for a static way to download a file with index, without taking consideration of the file name, i have added an option to download files by index.

I have implemented it this way: `?index=0..n`

 - When index is set, it download the file with that index from the latest release files.
 - If not set, it automatically bind the first file.
 - If a file name was set, it will behave normally as repository owner made it.

#### See it in action:

    https://chlegou.github.io/download_latest/chlegou/bitbot/ // will automatically bind the first file in the latest release
    https://chlegou.github.io/download_latest/chlegou/bitbot/?index=5 // will download the 5th file in the latest release 
    
**IMPORTANT:** In case of multi files, you must take consideration of file's orders in releases (they must follow the same order always to have it working right).

follow [this](https://github.com/niccokunzmann/download_latest/issues/3) issue for more details.

see changes from [here](https://github.com/chlegou/download_latest/blob/8720051371b81c94ec629bc64e37342c7440b8ef/_includes/github.js#L35-L44) for code details.


### IMPORTANT:

i have canceled the auto close, since isn't behaving correctly in mobile. (webpage must kept be opened, till user accept the download). otherwise, when webpage closed, the download dialog will be disappeared also.
